### PR TITLE
Fix locale prop for NextIntl provider

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -49,7 +49,7 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <NextIntlClientProvider messages={messages}>
+        <NextIntlClientProvider locale={locale} messages={messages}>
           <header className="container flex gap-4 justify-between items-center">
             <nav>
               <ul className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- pass `locale` prop to `NextIntlClientProvider`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bb0029348324b921628409cc9c90